### PR TITLE
fix for failover dns routing policy cloudformation

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,9 +157,10 @@ class Plugin {
     const regionSettings = this.serverless.service.custom.dns[this.options.region]
     if (regionSettings && regionSettings.failover) {
       properties.Failover = regionSettings.failover
+    } else {
+      properties.Region = this.options.region
     }
 
-    properties.Region = this.options.region
     properties.SetIdentifier = this.options.region
 
     const elements = resources.Outputs.RegionalEndpoint.Value['Fn::Join'][1]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-multi-region-plugin",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-multi-region-plugin",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Deploy an API Gateway service in multiple regions with a global CloudFront distribution and health checks",
   "author": "John Gilbert <john.gilbert@danteinc.com> (danteinc.com), Biller Direct Team",
   "license": "MIT",


### PR DESCRIPTION
If the DNS is configured for failover routing policy, don't specify a region property